### PR TITLE
Added Dockerfile and docker run Instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,7 @@ COPY setup.py README.rst ./
 RUN python setup.py install
 
 
-FROM ubuntu:18.04 as app
+FROM ubuntu:18.04 as prod
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
         libfreetype6 \
@@ -92,3 +92,13 @@ RUN groupadd -g 1000 mozaik \
 USER mozaik
 WORKDIR /app
 ENTRYPOINT ["python"]
+
+FROM prod as dev
+USER root
+RUN apt-get update \
+ && apt-get install -y \
+        python-pip \
+ && pip install pytest
+
+USER mozaik
+ENTRYPOINT [""]

--- a/Dockerfile
+++ b/Dockerfile
@@ -90,3 +90,5 @@ RUN groupadd -g 1000 mozaik \
  && useradd -m -u 1000 -g mozaik mozaik
 
 USER mozaik
+WORKDIR /app
+ENTRYPOINT ["python"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,24 +24,11 @@ RUN apt-get update \
         zlib1g-dev \
         wget
 
-RUN pip install --upgrade distribute \
- && pip install \
-        cython \
-        interval \
-        lazyarray \
-        matplotlib==2.1.1 \
-        mpi4py \
-        neo==0.5.2 \
-        numpy \
-        param==1.5.1 \
-        parameters \
-        Pillow \
-        psutil \
-        pynn \
-        quantities \
-        scipy
-
 WORKDIR /source
+COPY requirements.txt ./
+RUN pip install --upgrade distribute \
+ && pip install -r requirements.txt
+
 RUN git clone https://github.com/antolikjan/imagen.git \
  && cd imagen \
  && python setup.py install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,92 @@
+FROM ubuntu:18.04 as packages
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+ && apt-get install -y \
+        cmake \
+        g++ \
+        gfortran \
+        git \
+        libblas-dev \
+        libfreetype6-dev \
+        libgsl0-dev \
+        libjpeg8-dev \
+        liblapack-dev \
+        libncurses5-dev \
+        libopenmpi-dev \
+        libpng++-dev \
+        libreadline-dev \
+        openmpi-bin \
+        python-dev \
+        python-nose \
+        python-pip \
+        python-tk \
+        subversion \
+        zlib1g-dev \
+        wget
+
+RUN pip install --upgrade distribute \
+ && pip install \
+        cython \
+        interval \
+        lazyarray \
+        matplotlib==2.1.1 \
+        mpi4py \
+        neo==0.5.2 \
+        numpy \
+        param==1.5.1 \
+        parameters \
+        Pillow \
+        psutil \
+        pynn \
+        quantities \
+        scipy
+
+WORKDIR /source
+RUN git clone https://github.com/antolikjan/imagen.git \
+ && cd imagen \
+ && python setup.py install
+
+RUN wget https://github.com/nest/nest-simulator/archive/v2.20.0.tar.gz \
+ && tar xvfz v2.20.0.tar.gz \
+ && cd nest-simulator-2.20.0 \
+ && cmake \
+        -Dwith-mpi=OFF \
+        -Dwith-boost=ON \
+        -DCMAKE_INSTALL_PREFIX:PATH=/opt/nest \
+        -Dwith-optimize='-O3' \
+        ./ \
+ && make \
+ && make install
+
+WORKDIR /source/mozaik
+COPY mozaik ./mozaik
+COPY setup.py README.rst ./
+RUN python setup.py install
+
+
+FROM ubuntu:18.04 as app
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        libfreetype6 \
+        libgomp1 \
+        libgsl23 \
+        libjpeg8 \
+        libncurses5 \
+        libpython2.7 \
+        openmpi-bin \
+        python-nose \
+        python-six \
+        python-tk \
+        python2.7 \
+        ssh \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG PACKAGES_DIR=/usr/local/lib/python2.7/dist-packages
+COPY --from=packages $PACKAGES_DIR $PACKAGES_DIR
+COPY --from=packages /opt/nest /opt/nest
+ENV PYTHONPATH=/opt/nest/lib/python2.7/site-packages
+
+RUN groupadd -g 1000 mozaik \
+ && useradd -m -u 1000 -g mozaik mozaik
+
+USER mozaik

--- a/README.rst
+++ b/README.rst
@@ -198,13 +198,21 @@ Run the following commands to build a Docker container with Mozaik::
 
   git clone https://github.com/antolikjan/mozaik.git
   cd mozaik
-  docker build -t antolikjan/mozaik .
+  docker build --tag antolikjan/mozaik --target prod .
 
 To run the examples::
 
   cd examples
   cd VogelsAbbott2005
   docker run --rm -v "`pwd`:/app" antolikjan/mozaik run.py nest 2 param/defaults 'test'
+
+To build a development container::
+
+  docker build --tag antolikjan/mozaik:dev --target dev .
+
+To run tests::
+
+  docker run --rm -v "`pwd`:/app" antolikjan/mozaik:dev pytest
 
 :copyright: Copyright 2011-2013 by the *mozaik* team, see AUTHORS.
 :license: `CECILL <http://www.cecill.info/>`_, see LICENSE for details.

--- a/README.rst
+++ b/README.rst
@@ -189,5 +189,22 @@ Go to the examples directory in the mozaik cloned from github (see above) and la
   
 This will launch the example with the nest simulator, on 2 nodes with each node using 2 threads, using the parameter param/defaults. Last, 'test' is the name of this run.
 
+.. _ref-docker:
+
+Simple Installation with Docker
+-------------------------------
+
+Run the following commands to build a Docker container with Mozaik::
+
+  git clone https://github.com/antolikjan/mozaik.git
+  cd mozaik
+  docker build -t antolikjan/mozaik .
+
+To run the examples::
+
+  cd examples
+  cd VogelsAbbott2005
+  docker run --rm -v "`pwd`:/app" antolikjan/mozaik run.py nest 2 param/defaults 'test'
+
 :copyright: Copyright 2011-2013 by the *mozaik* team, see AUTHORS.
 :license: `CECILL <http://www.cecill.info/>`_, see LICENSE for details.

--- a/mozaik/sheets/population_selector.py
+++ b/mozaik/sheets/population_selector.py
@@ -234,7 +234,10 @@ class SimilarAnnotationSelectorRegion(SimilarAnnotationSelector):
       def generate_idd_list_of_neurons(self):
           picked_or = set(self.pick_close_to_annotation())
           xx,yy = self.sheet.cs_2_vf(self.sheet.pop.positions[0],self.sheet.pop.positions[1])
-          picked_region = set(numpy.arange(0,len(xx))[numpy.logical_and((abs(numpy.array(xx - self.parameters.offset_x) < self.parameters.size/2.0) , (abs(numpy.array(yy) - self.parameters.offset_y) < self.parameters.size/2.0))])
+          picked_region = set(numpy.arange(0,len(xx))[numpy.logical_and((
+              abs(numpy.array(xx - self.parameters.offset_x) < self.parameters.size/2.0),
+              abs(numpy.array(yy - self.parameters.offset_y) < self.parameters.size/2.0)
+          ))])
           picked = list(picked_or & picked_region)  
           mozaik.rng.shuffle(picked)
           z = self.sheet.pop.all_cells.astype(int)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+Cython==0.29.19
+interval==1.0.0
+lazyarray==0.3.3
+matplotlib==2.1.1
+mpi4py==3.0.3
+neo==0.5.2
+numpy==1.16.6
+param==1.5.1
+parameters==0.2.1
+Pillow==6.2.2
+psutil==5.7.0
+PyNN==0.9.5
+quantities==0.12.4
+scipy==1.2.3


### PR DESCRIPTION
## Purpose
Simplify and standardize installation with containers.

## Approach
Followed the existing installation instructions to create a Dockerfile for Mozaik based on Ubuntu 18.04.

## TODOs
- [ ] Use a more lightweight base image than Ubuntu
- [x] Pin python packages
- [ ] Pin system versions
- [ ] Prune unneeded packages (ssh?)

Also, the tests don't seem to pass. Each run produces slightly different results, but `assertAllClose()` is always _just barely_ off:
> AssertionError: The integral of multiplication of two gabors with parameters 3.307945,0.106894,0.261625,-2.535670,-4.695095,2.705986,0.244391,2.705986,2.673533 and 8.690291,0.288244,0.108628,-3.284550,-4.812920,2.507741,0.380479,2.507741,6.250486 does not match. Empirical value: -10.7661, analytical value: -10.7769.

I thought it might be due to upgrading Nest to 2.20.0, but downgrading to 2.18.0 produced the same results.