### PR TITLE
Fix typo in PopulationSelector.generate_idd_list_of_neurons()

### DIFF
--- a/mozaik/sheets/population_selector.py
+++ b/mozaik/sheets/population_selector.py
@@ -234,7 +234,10 @@ class SimilarAnnotationSelectorRegion(SimilarAnnotationSelector):
       def generate_idd_list_of_neurons(self):
           picked_or = set(self.pick_close_to_annotation())
           xx,yy = self.sheet.cs_2_vf(self.sheet.pop.positions[0],self.sheet.pop.positions[1])
-          picked_region = set(numpy.arange(0,len(xx))[numpy.logical_and((abs(numpy.array(xx - self.parameters.offset_x) < self.parameters.size/2.0) , (abs(numpy.array(yy) - self.parameters.offset_y) < self.parameters.size/2.0))])
+          picked_region = set(numpy.arange(0,len(xx))[numpy.logical_and((
+              abs(numpy.array(xx - self.parameters.offset_x) < self.parameters.size/2.0),
+              abs(numpy.array(yy - self.parameters.offset_y) < self.parameters.size/2.0)
+          ))])
           picked = list(picked_or & picked_region)  
           mozaik.rng.shuffle(picked)
           z = self.sheet.pop.all_cells.astype(int)


### PR DESCRIPTION
Extra close parens after yy