### PR TITLE
Simple and TwoStroke Gabor patch stimuli and experiment added.

### DIFF
--- a/mozaik/experiments/vision.py
+++ b/mozaik/experiments/vision.py
@@ -1723,3 +1723,423 @@ class MapResponseToInterruptedCornerStimulus(VisualExperiment):
 
     def do_analysis(self, data_store):
         pass
+
+
+class MapSimpleGabor(VisualExperiment):
+    """
+    Map RF with a Gabor patch stimuli.
+
+    This experiment presents a series of flashed Gabor patches at the centers
+    of regular hexagonal tides with given range of orientations.
+
+    
+    Parameters
+    ----------
+    model : Model
+          The model on which to execute the experiment.
+
+    Other parameters
+    ----------------
+    relative_luminance : float
+        Luminance of the Gabor patch relative to background luminance.
+        0. is dark, 1.0 is double the background luminance.
+
+    central_rel_lum : float
+        Luminance of the Gabor patch at the center of the RF relative to
+        background luminance.
+        0. is dark, 1.0 is double the background luminance.
+
+    orientation : float
+        The initial orientation of the Gabor patch.
+
+    phase : float
+        The phase of the Gabor patch.
+
+    spatial_frequency : float
+        The spatial freqency of the Gabor patch.
+
+    rotations : int
+        Number of different orientations at each given place.
+        1 only one Gabor patch with initial orientation will be presented at
+        given place, N>1 N different orientations will be presented, 
+        orientations are uniformly distributed between [0, 2*pi) + orientation.
+
+    size : float
+        Size of the tides. From this value the size of Gabor patch is derived 
+        so that it fits into a circle with diameter equal to this size.
+
+        Gabor patch size is set so that sigma of Gaussian envelope is size/3
+
+    x : float
+        The x corrdinates of the central tide.
+
+    y : float
+        The y corrdinates of the central tide.
+
+    flash_duration : float
+        The duration of the presentation of a single Gabor patch. 
+
+    duration : float
+        The duration of single presentation of the stimulus.
+
+    num_trials : int
+        Number of trials each each stimulus is shown.
+
+    circles : int
+        Number of "circles" where the Gabor patch is presented.
+        1: only at the central point the Gabor patch is presented, 
+        2: stimuli are presented at the central hexagonal tide and 6 hexes 
+        forming a "circle" around the central
+
+    grid : bool
+        If True hexagonal tiding with relative luminance 0 is drawn over the 
+        stimmuli.
+        Mostly for testing purposes to check the stimuli are generated 
+        correctly.
+
+    Note on hexagonal tiding:
+    -------------------------
+        Generating coordinates of centers of regular (!) hexagonal tidings.
+        It is done this way, because the centers of tides are not on circles (!)
+        First it generates integer indexed centers like this:
+              . . .                (-2,2) (0, 2) (2,2)
+             . . . .           (-3,1) (-1,1) (1,1) (3,1)
+            . . . . .   ==> (-4,0) (-2,0) (0,0) (2,0) (4,0)     (circles=3)
+             . . . .           (-3,-1)(-1,-1)(1,-1)(3,-1)
+              . . .                (-2,-2)(0,-2)(2,-2)
+
+        coordinates then multiplied by non-integer factor to get the right position
+            x coordinate multiplied by factor 1/2*size
+            y coordinate multiplied by factor sqrt(3)/2*size
+
+    Note on central relative luminance:
+    -----------------------------------
+        In the experiment they had lower luminance for Gabor patches presented
+        at the central tide
+    """
+
+    required_parameters = ParameterSet({
+            'relative_luminance' : float,
+            'central_rel_lum' : float,
+            'orientation' : float,
+            'phase' : float,
+            'spatial_frequency' : float,
+            'size' : float,
+            'flash_duration' : float, 
+            'x' : float,
+            'y' : float,
+            'rotations' : int,
+            'duration' : float,
+            'num_trials' : int,
+            'circles' : int,
+            'grid' : bool,
+    })
+
+
+    def __init__(self, model, parameters):
+        VisualExperiment.__init__(self, model, parameters)
+        if self.parameters.grid:
+            # Grid is currently working only for special cases
+            # Check if it is working
+            assert self.parameters.x == 0, "X shift not yet implemented"
+            assert self.parameters.y == 0, "Y shift not yet implemented"
+            assert model.visual_field.size_x == model.visual_field.size_y, "Different sizes not yet implemented"
+        for trial in xrange(0, self.parameters.num_trials):
+            for rot in xrange(0, self.parameters.rotations):
+                for row in xrange(self.parameters.circles-1, -self.parameters.circles,-1):
+                    colmax =  2*self.parameters.circles-2 - abs(row)
+                    for column in xrange(-colmax, colmax + 1, 2):
+                        # central coordinates of presented Gabor patch
+                        # relative to the central tide
+                        x = column*0.5*self.parameters.size
+                        y = row*0.5*self.parameters.size  
+                        # different luminance for central tide
+                        if column == 0 and row == 0:
+                            rel_lum = self.parameters.central_rel_lum
+                        else:
+                            rel_lum = self.parameters.relative_luminance
+                        self.stimuli.append(
+                            topo.SimpleGaborPatch(
+                                frame_duration = self.frame_duration,
+                                duration=self.parameters.duration,
+                                flash_duration = self.parameters.flash_duration,
+                                size_x=model.visual_field.size_x,
+                                size_y=model.visual_field.size_y,
+                                background_luminance=self.background_luminance,
+                                relative_luminance = rel_lum,
+                                orientation = (self.parameters.orientation 
+                                            + numpy.pi*rot/self.parameters.rotations),
+                                density=self.density,
+                                phase = self.parameters.phase,
+                                spatial_frequency = self.parameters.spatial_frequency,
+                                size = self.parameters.size,
+                                x = self.parameters.x + x,
+                                y = self.parameters.y + y,
+                                location_x=0.0,
+                                location_y=0.0,
+                                trial=trial))
+
+    def do_analysis(self, data_store):
+        pass
+
+
+class MapTwoStrokeGabor(VisualExperiment):
+    """
+    Map RF with a two stroke Gabor patch stimuli to study response on apparent
+    movement. First a Gabor patch is presented for specified time after that
+    another Gabor patch is presented at neighbohring tide with same orientation
+    and other properties.
+
+    There are two configuration for the movement:
+        ISO i.e. Gabor patch moves parallel to its orientation
+        CROSS i.e. Gabor patch moves perpendicular to its orientation
+        
+        In any case it has to move into another tide, therefore orientation 
+        determines the configuration
+
+  
+    Parameters
+    ----------
+    model : Model
+          The model on which to execute the experiment.
+
+    Other parameters
+    ----------------
+    relative_luminance : float
+        Luminance of the Gabor patch relative to background luminance.
+        0. is dark, 1.0 is double the background luminance.
+
+    central_rel_lum : float
+        Luminance of the Gabor patch at the center of the RF relative to
+        background luminance.
+        0. is dark, 1.0 is double the background luminance.
+
+    orientation : float
+        The initial orientation of the Gabor patch.
+        This changes orientation of the whole experiment, i.e. it also rotates 
+        the grid (because of the iso and cross configurations of movements).
+
+    phase : float
+        The phase of the Gabor patch.
+
+    spatial_frequency : float
+        The spatial freqency of the Gabor patch.
+
+    rotations : int
+        Number of different orientations at each given place.
+        1 only one Gabor patch with initial orientation will be presented at
+        given place, N>1 N different orientations will be presented, 
+        orientations are uniformly distributed between [0, 2*pi) + orientation.
+
+    size : float
+        Size of the tides. From this value the size of Gabor patch is derived 
+        so that it fits into a circle with diameter equal to this size.
+
+        Gabor patch size is set so that sigma of Gaussian envelope is size/3
+
+    x : float
+        The x corrdinates of the central tide.
+
+    y : float
+        The y corrdinates of the central tide.
+
+    stroke_time : float
+        The duration of the first stroke of Gabor patch
+
+    flash_duration : float
+        The total duration of the presentation of Gabor patches. Therefore,
+        the second stroke is presented for time equal: 
+            flash_duration - stroke_tim 
+
+    duration : float
+        The duration of single presentation of the stimulus.
+
+    num_trials : int
+        Number of trials each each stimulus is shown.
+
+    circles : int
+        Number of "circles" where the Gabor patch is presented.
+        1: only at the central point the Gabor patch is presented, 
+        2: stimuli are presented at the central hexagonal tide and 6 hexes 
+        forming a "circle" around the central
+        Trajectories starting or ending in the given number of circles are
+        used, i.e. First Gabor patch can be out of the circles and vice versa.
+
+    grid : bool
+        If True hexagonal tiding with relative luminance 0 is drawn over the 
+        stimmuli.
+        Mostly for testing purposes to check the stimuli are generated 
+        correctly.
+
+    Note on hexagonal tiding:
+    -------------------------
+        Generating coordinates of centers of regular (!) hexagonal tidings.
+        It is done this way, because the centers of tides are not on circles (!)
+        First it generates integer indexed centers like this:
+              . . .                (-2,2) (0, 2) (2,2)
+             . . . .           (-3,1) (-1,1) (1,1) (3,1)
+            . . . . .   ==> (-4,0) (-2,0) (0,0) (2,0) (4,0)     (circles=3)
+             . . . .           (-3,-1)(-1,-1)(1,-1)(3,-1)
+              . . .                (-2,-2)(0,-2)(2,-2)
+
+        coordinates then multiplied by non-integer factor to get the right position
+            x coordinate multiplied by factor 1/2*size
+            y coordinate multiplied by factor sqrt(3)/2*size
+
+    Note on central relative luminance:
+    -----------------------------------
+        In the experiment they had lower luminance for Gabor patches presented
+        at the central tide
+
+
+    Note on number of circles:
+    --------------------------
+        For 2 stroke the experiment includes also the trajectories that
+        start inside the defined number of circles but get out as well as 
+        trajectories starting in the outside layer of tides comming inside.
+
+        For example if we have number of circles = 2 -> that means we have 
+        central tide and the first circle of tides around, but for two stroke
+        it is possible we start with Gabor patch at the distance 2 tides away
+        from the central tide (i.e. tides that are in circles = 3) if we move 
+        inside and vice versa.
+
+        This is solved by checking the distance of the final position of the 
+        Gabor patch, if the distance is bigger than a radius of a circle
+        then opposite direction is taken into account.
+        
+        Since we have hexagonal tides this check is valid only for 
+        n <= 2/(2-sqrt(3)) ~ 7.5 
+        which is for given purposes satisfied, but should be mentioned.
+
+    Note on rotations:
+    ------------------
+        This number is taken as a free parameter, but to replicate hexagonal
+        tiding this number has to be 6 or 1 or 2. The code exploits symmetry and
+        properties of the hexagonal tiding rather a lot!
+        The ISO/CROSS configuration is determined from this number, so any other
+        number generates moving paterns but in directions not matching hexes.
+
+    """
+
+    required_parameters = ParameterSet({
+            'relative_luminance' : float,
+            'central_rel_lum' : float,
+            'orientation' : float,
+            'phase' : float,
+            'spatial_frequency' : float,
+            'size' : float,
+            'flash_duration' : float, 
+            'x' : float,
+            'y' : float,
+            'rotations' : int,
+            'duration' : float,
+            'num_trials' : int,
+            'circles' : int,
+            'stroke_time' : float,
+            'grid' : bool,
+            })  
+
+
+    def __init__(self, model, parameters):
+        VisualExperiment.__init__(self, model, parameters)
+        # Assert explained in docstring
+        assert self.parameters.circles < 7, "Too many circles, this won't work"
+        if self.parameters.grid:
+            # Grid is currently working only for special cases
+            # Check if it is working
+            assert self.parameters.orientation == 0., "Rotated grid is not implemented"
+            assert self.parameters.x == 0, "X shift not yet implemented"
+            assert self.parameters.y == 0, "Y shift not yet implemented"
+            assert model.visual_field.size_x == model.visual_field.size_y, "Different sizes not yet implemented"
+
+
+        for trial in xrange(0, self.parameters.num_trials):
+            for rot in xrange(0, self.parameters.rotations):
+                for row in xrange(self.parameters.circles-1, -self.parameters.circles,-1):
+                    colmax =  2*self.parameters.circles-2 - abs(row)
+                    for column in xrange(-colmax, colmax + 1, 2):
+                        for direction in (-1,1):
+                            # central coordinates of presented Gabor patch
+                            # relative to the central tide
+                            x = column*0.5*self.parameters.size
+                            y = row*0.5*numpy.sqrt(3)*self.parameters.size  
+                            # rotation of the Gabor
+                            angle = (self.parameters.orientation 
+                                    + numpy.pi*rot/self.parameters.rotations)
+                            if rot%2 == 0: # even rotations -> iso config
+                                # Gabor orientation 0 -> horizontal
+                                x_dir = numpy.cos(angle)*self.parameters.size
+                                y_dir = numpy.sin(angle)*self.parameters.size
+                            else:  # odd rotations -> cross config
+                                # cross config means moving into perpendicular
+                                # direction (aka + pi/2)
+                                x_dir = -numpy.sin(angle)*self.parameters.size
+                                y_dir = numpy.cos(angle)*self.parameters.size
+
+                            # starting in the central tide
+                            if x == 0 and y == 0:
+                                first_rel_lum = self.parameters.central_rel_lum
+                                second_rel_lum = self.parameters.relative_luminance
+                            # ending in the central tide
+                            elif ((abs(x + x_dir*direction) < self.parameters.size/2.) and
+                                  (abs(y + y_dir*direction) < self.parameters.size/2.)):
+                                first_rel_lum = self.parameters.relative_luminance
+                                second_rel_lum = self.parameters.central_rel_lum
+                            # far from the central tide
+                            else:
+                                first_rel_lum = self.parameters.relative_luminance
+                                second_rel_lum = self.parameters.relative_luminance
+
+
+                            # If the Gabor patch ends in outer circle
+                            # we want also Gabor moving from outer circle to 
+                            # inner circles 
+                            # This condition is approximated by concentric 
+                            # circles more in docstring
+                            outer_circle = numpy.sqrt((x+x_dir*direction)**2 
+                                        + (y+y_dir*direction)**2) > (
+                                                (self.parameters.circles-1)
+                                                *self.parameters.size)
+
+                            # range here is 1 or 2
+                            # In case of outer_circle == True generates two
+                            # experiments, from and into the outer circle
+                            # In case of outer_circle == False generates only
+                            # one experiment
+                            for inverse in xrange(1+outer_circle):
+                                self.stimuli.append(
+                                    topo.TwoStrokeGaborPatch(
+                                        frame_duration = self.frame_duration,
+                                        duration=self.parameters.duration,
+                                        flash_duration = self.parameters.flash_duration,
+                                        size_x=model.visual_field.size_x,
+                                        size_y=model.visual_field.size_y,
+                                        background_luminance=self.background_luminance,
+                                        first_relative_luminance = first_rel_lum,
+                                        second_relative_luminance = second_rel_lum,
+                                        orientation = angle,
+                                        density=self.density,
+                                        phase = self.parameters.phase,
+                                        spatial_frequency = self.parameters.spatial_frequency,
+                                        size = self.parameters.size,
+                                        x = self.parameters.x + x + inverse*x_dir*direction,
+                                            # inverse == 0 -> original start
+                                            # inverse == 1 -> start from end
+                                        y = self.parameters.y + y + inverse*y_dir*direction,
+                                        location_x=0.0,
+                                        location_y=0.0,
+                                        trial=trial,
+                                        stroke_time=self.parameters.stroke_time,
+                                        x_direction=x_dir*direction*((-1)**inverse),
+                                            # (-1)**inverse = 1 for original one
+                                            # == -1 for the inverse movement
+                                        y_direction=y_dir*direction*((-1)**inverse),
+                                        grid=self.parameters.grid,
+                                        ))
+                                # For the inverse movement we have to 
+                                # switch the luminances
+                                first_rel_lum, second_rel_lum = second_rel_lum, first_rel_lum
+
+    def do_analysis(self, data_store):
+        pass

--- a/mozaik/stimuli/vision/topographica_based.py
+++ b/mozaik/stimuli/vision/topographica_based.py
@@ -812,3 +812,263 @@ class VonDerHeydtIllusoryBar(TopographicaBasedVisualStimulus):
                 yield (numpy.add(d1,d2),[1])
             else:
                 yield (b,[0])
+
+
+class SimpleGaborPatch(TopographicaBasedVisualStimulus):
+    """A flash of a Gabor patch
+
+    This stimulus corresponds to flashing a Gabor patch of a specific
+    *orientation*, *size*, *phase*, *spatial_frequency* at a defined position
+    *x* and *y* for *flash_duration* milliseconds. For the remaining time, 
+    until the *duration* of the stimulus, constant *background_luminance* 
+    is displayed.
+    """
+
+    orientation = SNumber(rad, period=pi, bounds=[0,pi], doc="Gabor patch orientation")
+    phase = SNumber(rad, period=2*pi, bounds=[0,2*pi], doc="Gabor patch phase")
+    spatial_frequency = SNumber(cpd, doc="Spatial frequency of the grating")
+    size = SNumber(degrees, doc="Size of the Gabor patch")
+    flash_duration = SNumber(ms, doc="The duration of the bar presentation.")
+    relative_luminance = SNumber(dimensionless,bounds=[0,1.0],doc="The scale of the stimulus. 0 is dark, 1.0 is double the background luminance")
+    x = SNumber(degrees, doc="The x location of the center of the Gabor patch.")
+    y = SNumber(degrees, doc="The y location of the center of the Gabor patch.")
+    grid = SNumber(dimensionless, doc = "Boolean string to decide whether there is grid or not")
+
+
+    def frames(self):
+        num_frames = 0
+        if self.grid:
+            grid_pattern = hex_grid()
+        while True:
+            gabor = imagen.Gabor(
+                        aspect_ratio = 1, # Ratio of pattern width to height.
+                                          # Set since the patch has to be round
+                        mask_shape=imagen.Disk(smoothing=0, size=3*self.size),
+                            # Gabor patch should fit inside tide/circle
+                            # the size is rescalled according to the size
+                            # of Gabor patch
+                        frequency = self.spatial_frequency,
+                        phase = self.phase, # Initial phase of the sinusoid
+                        bounds = BoundingBox(radius=self.size_x/2.), 
+                            # BoundingBox of the
+                            # area in which the pattern is generated,
+                            # radius=1: box with side length 2!
+                        size = self.size/3, # size = 2*standard_deviation
+                            # => on the radius r=size, the intensity is ~0.14
+                        orientation=self.orientation, # In radians
+                        x = self.x,  # x-coordinate of Gabor patch center
+                        y = self.y,  # y-coordinate of Gabor patch center
+                        xdensity=self.density, # Number of points in one unit of length in x direction
+                        ydensity=self.density, # Number of points in one unit of length in y direction
+                        scale=2*self.background_luminance*self.relative_luminance, 
+                                # Difference between maximal and minimal value 
+                                # => min value = -scale/2, max value = scale/2
+                                )()
+            gabor = gabor+self.background_luminance # rescalling
+            blank = imagen.Constant(scale=self.background_luminance,
+                                    bounds=BoundingBox(radius=self.size_x/2),
+                                    xdensity=self.density,
+                                    ydensity=self.density)()
+            if self.grid:
+                gabor = gabor*grid_pattern
+                blank = blank*grid_pattern
+            num_frames += 1
+            if (num_frames-1) * self.frame_duration < self.flash_duration: 
+                yield (gabor, [1])
+            else:
+                yield (blank, [0])
+
+    def hex_grid(self):
+        """Creates an 2D array representing hexagonal grid based on given parameters
+
+        Algorithm:
+            First, it creates a tide containing two lines looking like: ___/
+                the height of the tide is size/2
+                the width of the tide is sqrt(3)/2*size
+                NOTE: one of the parameters is not an integer -> therefore rounding
+                    is present and for big grids it can be off by several pixels
+                    the oddness can be derived from the ratio of width and height
+                    the more close to sqrt(3) the better
+
+            Second, it replicates the the tide to create hexagonal tiding of the 
+            following form              ___ 
+                                    ___/   \
+                                       \___/
+            Third, it replicates the hexagonal tide and rotates it
+
+            Fourth, it computes shifts based on parameters size, size_x, size_y
+                    and cuts out the relevant part of the array
+
+        Returns:
+            array with values 1 or 0, 0 representing the hexagonal grid
+        """
+        # imagen is used to create the slant line /
+        ln = imagen.Line(bounds = BoundingBox(radius=self.size/4.), 
+                    orientation = pi/3, smoothing=0,
+                    xdensity = self.density, ydensity = self.density,  
+                    thickness=1./self.density)()
+        # cutting the relevant part of the created line
+        idx = ln.argmax(axis=0).argmax()
+        line = ln[:,idx:-idx]
+        # Creating the horizontal line _
+        hline = numpy.zeros((line.shape[0], line.shape[1]*2))
+        hline[-1,:] = 1
+        # Creating hexagonal tide
+        tide = numpy.hstack((hline,line))  # joins horizontal line and slant line
+        tide = numpy.hstack((tide, tide[::-1,:]))  # mirrors the tide in horizontal direction
+        tide = numpy.vstack((tide, tide[::-1,:]))  # mirrors the tide in vertical direction
+        d, k = tide.shape
+        k = k/3
+        # Creating hex
+        x_reps = int(self.size_x/self.size) + 2
+        y_reps = int(self.size_y/self.size) + 2
+        # pixel sizes
+        x_size = int(self.size_x*self.density)
+        y_size = int(self.size_y*self.density)
+        grid = numpy.hstack((numpy.vstack((tide,)*y_reps),)*x_reps)
+        # starting indices in each dimension
+        i = int((0.5+int(self.size_y/self.size)*1.5)*k)-int(self.density*self.size_y/2)
+        j = d - int(self.size_x%self.size*self.density/2.)
+        grid = grid[j:j+x_size,i:i+y_size]
+        center = grid.shape[0]/2
+        return 1-grid.T
+
+
+class TwoStrokeGaborPatch(TopographicaBasedVisualStimulus):
+    """A flash of two consecutive Gabor patches next to each other
+
+    This stimulus corresponds to flashing a Gabor patch of a specific
+    *orientation*, *size*, *phase*, *spatial_frequency* starting at a defined
+    position *x* and *y* for *stroke_time* milliseconds. After that time
+    Gabor patch is moved in the *x_direction* and *y_direction* to new place,
+    where is presented until the *flash_duration* milliseconds from start of
+    the experiment passes. For the remaining time,  until the *duration* of the
+    stimulus, constant *background_luminance* is displayed.
+    """
+
+    orientation = SNumber(rad, period=pi, bounds=[0,pi], doc="Gabor patch orientation")
+    phase = SNumber(rad, period=2*pi, bounds=[0,2*pi], doc="Gabor patch phase")
+    spatial_frequency = SNumber(cpd, doc="Spatial frequency of the grating")
+    size = SNumber(degrees, doc="Size of the Gabor patch")
+    flash_duration = SNumber(ms, doc="The duration of the bar presentation.")
+    first_relative_luminance = SNumber(dimensionless,bounds=[0,1.0], doc="The scale of the stimulus. 0 is dark, 1.0 is double the background luminance")
+    second_relative_luminance = SNumber(dimensionless,bounds=[0,1.0],doc="The scale of the stimulus. 0 is dark, 1.0 is double the background luminance")
+    x = SNumber(degrees, doc="The x location of the center of the Gabor patch.")
+    y = SNumber(degrees, doc="The y location of the center of the Gabor patch.")
+    stroke_time = SNumber(ms, doc="Duration of the first stroke.")
+    x_direction = SNumber(degrees, doc="The x direction for the second stroke.")
+    y_direction = SNumber(degrees, doc="The y direction for the second stroke.")
+    grid = SNumber(dimensionless, doc = "Boolean string to decide whether there is grid or not")
+
+
+    def frames(self):
+        num_frames = 0
+        # relative luminance of a current stroke
+        current_luminance = self.first_relative_luminance
+        if self.grid:
+            grid_pattern = self.hex_grid()
+        while True:
+            gabor = imagen.Gabor(
+                        aspect_ratio = 1, # Ratio of pattern width to height.
+                                          # Set since the patch has to be round
+                        mask_shape=imagen.Disk(smoothing=0, size=3*self.size),
+                            # Gabor patch should fit inside tide/circle
+                            # the size is rescalled according to the size
+                            # of Gabor patch
+                        frequency = self.spatial_frequency,
+                        phase = self.phase, # Initial phase of the sinusoid
+                        bounds = BoundingBox(radius=self.size_x/2), 
+                            # BoundingBox of the area in which the pattern is
+                            # generated, radius=1: box with side length 2!
+                        size = self.size/3, # size = 2*standard_deviation
+                            # => on the radius r=size, the intensity is ~0.14
+                        orientation=self.orientation, # In radians
+                        x = self.x,  # x-coordinate of Gabor patch center
+                        y = self.y,  # y-coordinate of Gabor patch center
+                        xdensity=self.density, # Number of points in one unit 
+                                               # of length in x direction
+                        ydensity=self.density, # Number of points in one unit 
+                                               # of length in y direction
+                        scale=2*self.background_luminance*current_luminance,
+                                # Difference between maximal and minimal value 
+                                # => min value = -scale/2, max value = scale/2
+                                )()                
+            gabor = gabor+self.background_luminance # rescalling
+            blank = imagen.Constant(scale=self.background_luminance,
+                                    bounds=BoundingBox(radius=self.size_x/2),
+                                    xdensity=self.density,
+                                    ydensity=self.density)()
+            if self.grid:
+                gabor = gabor*grid_pattern
+                blank = blank*grid_pattern
+            num_frames += 1
+            if (num_frames-1) * self.frame_duration < self.stroke_time: 
+                # First stroke
+                yield (gabor, [1])
+                if num_frames * self.frame_duration >= self.stroke_time:
+                    # If next move is the second stroke -> change position 
+                    # and luminance
+                    self.x = self.x + self.x_direction 
+                    self.y = self.y + self.y_direction 
+                    current_luminance = self.second_relative_luminance
+            elif (num_frames-1) * self.frame_duration < self.flash_duration: 
+                # Second stroke
+                yield (gabor, [1])
+            else:
+                yield (blank, [0])
+    
+    def hex_grid(self):
+        """Creates an 2D array representing hexagonal grid based on the parameters
+
+        Algorithm:
+            First, it creates a tide containing two lines looking like: ___/
+                the height of the tide is size/2
+                the width of the tide is sqrt(3)/2*size
+                NOTE: one of the parameters is not an integer -> therefore rounding
+                    is present and for big grids it can be off by several pixels
+                    the oddness can be derived from the ratio of width and height
+                    the more close to sqrt(3) the better
+
+            Second, it replicates the the tide to create hexagonal tiding of the 
+            following form              ___ 
+                                    ___/   \
+                                       \___/
+            Third, it replicates the hexagonal tide and rotates it
+
+            Fourth, it computes shifts based on parameters size, size_x, size_y
+                    and cuts out the relevant part of the array
+
+        Returns:
+            array with values 1 or 0, 0 representing the hexagonal grid
+        """
+        # imagen is used to create the slant line /
+        ln = imagen.Line(bounds = BoundingBox(radius=self.size/4.), 
+                    orientation = pi/3, smoothing=0,
+                    xdensity = self.density, ydensity = self.density,  
+                    thickness=1./self.density)()
+        # cutting the relevant part of the created line
+        idx = ln.argmax(axis=0).argmax()
+        line = ln[:,idx:-idx]
+        # Creating the horizontal line _
+        hline = numpy.zeros((line.shape[0], line.shape[1]*2))
+        hline[-1,:] = 1
+        # Creating hexagonal tide
+        tide = numpy.hstack((hline,line))  # joins horizontal line and slant line
+        tide = numpy.hstack((tide, tide[::-1,:]))  # mirrors the tide in horizontal direction
+        tide = numpy.vstack((tide, tide[::-1,:]))  # mirrors the tide in vertical direction
+        d, k = tide.shape
+        k = k/3
+        # Creating hex
+        x_reps = int(self.size_x/self.size) + 2
+        y_reps = int(self.size_y/self.size) + 2
+        # pixel sizes
+        x_size = int(self.size_x*self.density)
+        y_size = int(self.size_y*self.density)
+        grid = numpy.hstack((numpy.vstack((tide,)*y_reps),)*x_reps)
+        # starting indices in each dimension
+        i = int((0.5+int(self.size_y/self.size)*1.5)*k)-int(self.density*self.size_y/2)
+        j = d - int(self.size_x%self.size*self.density/2.)
+        grid = grid[j:j+x_size,i:i+y_size]
+        center = grid.shape[0]/2
+        return 1-grid.T
+


### PR DESCRIPTION
Simple Gabor patch represents presentation of static Gabor patches at the centers of hexagonal tidings. Algorithm computes the centers of hexagonal tides and place a Gabor patch for a specified time onto that position, it can also try multiple rotations.

TwoStroke Gabor patch represents presentation of Gabor pathes that "moves" from one hexagonal tide into neighboring hexagonal tide creating so called apparent movement.